### PR TITLE
Added color temperature functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Changes the light state, effect, color and brightness based on the passed in **m
 | **hex**            	| string             	| Optionally configurable HEX color value of the light bulb. You don't need to pass the HEX value if you already passed a RGB value 	|
 | **transitionTime** 	| int                	| Optionally configurable temporary value which eases transition of an effect (value in seconds, 0 for instant, 5 for five seconds) 	|
 | **colorloop**      	| int                	| Optionally configurable color loop effect. Value in seconds (deactivates the effect to the previous state after x seconds)        	|
+| **colorTemp**       | int               | Optionally configurable color temperature of the light from 153 to 500
 
 ### Special Alert Effect
 Plays an alert effect based on the passed in **msg.payload** values of:

--- a/red/hue-light.js
+++ b/red/hue-light.js
@@ -189,7 +189,18 @@ module.exports = function(RED)
 						{
 							light.xy = rgb.convertRGBtoXY(hexRGB((msg.payload.hex).toString()), light.modelid);
 						}
-
+						//SET COLOR TEMPERATURE
+                                                if(msg.payload.colorTemp && light.colorTemp)
+                                                {
+                                                        let colorTemp = parseInt(msg.payload.colorTemp);
+                                                        if(colorTemp >= 153 && colorTemp <= 500)
+                                                        {
+                                                                light.colorTemp = parseInt(msg.payload.colorTemp);
+                                                        } else {
+                                                                scope.error("Invalid color temprature. Only 153 - 500 allowed");
+                                                                return false;
+                                                        }
+                                                }
 						// SET TRANSITION TIME
 						if(msg.payload.transitionTime)
 						{


### PR DESCRIPTION
Color temperature of a single light can now be set with a payload which has the colorTemp field set to a value between 153 and 500. This change is also reflected in the readme.