### PR TITLE
Correct important typo in temperature.js

### DIFF
--- a/red/hue-temperature.js
+++ b/red/hue-temperature.js
@@ -72,7 +72,7 @@ module.exports = function(RED)
 				}
 			})
 			.catch(error => {
-				score.error(error);
+				scope.error(error);
 				scope.status({fill: "red", shape: "ring", text: "connection error"});
 			});
 		}, parseInt(bridge.config.interval));


### PR DESCRIPTION
I introduced a small (but critical) typo in my last pull request, sorry about that, should be good to go now ! (typed score instead of scope)
Thanks