### PR TITLE
Fix human readable colors; pass array not object

### DIFF
--- a/red/hue-light.js
+++ b/red/hue-light.js
@@ -15,7 +15,7 @@ module.exports = function(RED)
 		let colornames = require("colornames");
 		let colornamer = require('color-namer');
 
-		
+
 		//
 		// CHECK CONFIG
 		if(bridge == null)
@@ -259,7 +259,8 @@ module.exports = function(RED)
 						var colorHex = colornames(msg.payload.color);
 						if(colorHex)
 						{
-							light.xy = rgb.convertRGBtoXY(hexRGB(colorHex), light.model.id);
+							var rgbResult = hexRGB(colorHex);
+							light.xy = rgb.convertRGBtoXY([rgbResult.red, rgbResult.green, rgbResult.blue], light.model.id);
 						}
 					}
 


### PR DESCRIPTION
First of all, thanks so much for putting this great library out there!

I found that passing any human readable color payload such as:

```
{
  color: "red"
}
```

...would always result in the light turning `blue` no matter what the color.  After some debugging I realized that when calling `convertRGBtoXY` it was passing:

```
{
  "red": 255,
  "green": 0,
  "blue": 0,
  "alpha": 255
}
```

However, the `convertRGBtoXY` function was expecting an array:

```
  convertRGBtoXY: function(rgb, model) {
    var red = rgb[0];
    var green = rgb[1];
    var blue = rgb[2];
```

This results in each of these 3 variables being `NaN` and the `xy` value becomes `[0,0]` which the hue resolves to blue.

The other functions calling this do the array conversion beforehand, but it seems that just in this one case the object is being passed in its original form.  The fix converts it to the ordered array representation first.

Tested using many named colors such as `red`, `yellow`, `purple` and now works correctly.

Fixes #79