### PR TITLE
Added helper function to generate random hex colors

### DIFF
--- a/huemagic/hue-group.js
+++ b/huemagic/hue-group.js
@@ -21,6 +21,7 @@ module.exports = function(RED)
 		let hexRGB = require('hex-rgb');
 		let colornames = require("colornames");
 		let getColors = require('get-image-colors');
+		let {randomHexColor} = require('../utils/color');
 
 		//
 		// CHECK CONFIG
@@ -139,7 +140,7 @@ module.exports = function(RED)
 						{
 							if(new RegExp("random|any|whatever").test(msg.payload.color))
 							{
-								var randomColor = '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+								var randomColor = randomHexColor();
 								var rgbResult = hexRGB(randomColor);
 								group.xy = rgb.convertRGBtoXY([rgbResult.red, rgbResult.green, rgbResult.blue], false);
 							}
@@ -332,7 +333,7 @@ module.exports = function(RED)
 					{
 						if(new RegExp("random|any|whatever").test(msg.payload.color))
 						{
-							var randomColor = '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+							var randomColor = randomHexColor();
 							var rgbResult = hexRGB(randomColor);
 							group.xy = rgb.convertRGBtoXY([rgbResult.red, rgbResult.green, rgbResult.blue], false);
 						}

--- a/huemagic/hue-light.js
+++ b/huemagic/hue-light.js
@@ -21,6 +21,7 @@ module.exports = function(RED)
 		let hexRGB = require('hex-rgb');
 		let colornames = require("colornames");
 		let getColors = require('get-image-colors');
+		let {randomHexColor} = require('../utils/color');
 
 		//
 		// CHECK CONFIG
@@ -151,7 +152,7 @@ module.exports = function(RED)
 						{
 							if(new RegExp("random|any|whatever").test(msg.payload.color))
 							{
-								var randomColor = '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+								var randomColor = randomHexColor();
 								var rgbResult = hexRGB(randomColor);
 								light.xy = rgb.convertRGBtoXY([rgbResult.red, rgbResult.green, rgbResult.blue], light.model.id);
 							}
@@ -354,7 +355,7 @@ module.exports = function(RED)
 					{
 						if(new RegExp("random|any|whatever").test(msg.payload.color))
 						{
-							var randomColor = '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+							var randomColor = randomHexColor();
 							var rgbResult = hexRGB(randomColor);
 							light.xy = rgb.convertRGBtoXY([rgbResult.red, rgbResult.green, rgbResult.blue], light.model.id);
 						}

--- a/huemagic/hue-magic.html
+++ b/huemagic/hue-magic.html
@@ -217,6 +217,9 @@
                         return rgb;
                     }
 
+                    function randomHexColor() {
+                        return '#' + (Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, "0");
+                    }
 
                     // FRAMES
                     function addPreviewFrame(step)
@@ -242,7 +245,7 @@
                         {
                             if(step.animation.color == "random"||step.animation.color == "any")
                             {
-                                color = '#'+(Math.random()*0xFFFFFF<<0).toString(16);
+                                color = randomHexColor();
                             }
                             else
                             {

--- a/utils/color.js
+++ b/utils/color.js
@@ -1,0 +1,9 @@
+module.exports = {
+	/**
+	 * Generates a random 6 digit hex string
+	 * @return {string}
+	 */
+	randomHexColor: function () {
+		return '#' + (Math.random() * 0xFFFFFF << 0).toString(16).padStart(6, "0");
+	}
+}


### PR DESCRIPTION
This PR fixes issue #189 and #146.

The new random color function assures that the output is a six digit hex string.
The old random color generation could create 5 digit hex strings if the generated number was lower than 0x100000.

I have tested this on my local node-red device and it works as expected.