### PR TITLE
Fixed "err is node defined" error.

### DIFF
--- a/huemagic/utils/api.js
+++ b/huemagic/utils/api.js
@@ -154,7 +154,7 @@ function API()
 				// ERROR? -> RETRY?
 				scope.events[config.id].onerror = function(error)
 				{
-					console.log("HueMagic:", "Connection to bridge lost. Trying to reconnect again in 30 seconds…", err);
+					console.log("HueMagic:", "Connection to bridge lost. Trying to reconnect again in 30 seconds…", error);
 					setTimeout(function(){ scope.subscribe(config, callback); }, 30000);
 					resolve(true);
 				}


### PR DESCRIPTION
Whenever the node lost connection to the hub, it logs the disconnection but in the log line, there is an "err" object not defined. Replaced with the right "error" object.