### PR TITLE
Fix wrong For Loop for gradient in HueLightMessage

### DIFF
--- a/huemagic/utils/messages.js
+++ b/huemagic/utils/messages.js
@@ -219,7 +219,7 @@ class HueLightMessage
 			this.message.payload.gradient = {};
 			this.message.payload.gradient.colors = [];
 
-			for(let gradientColor in service["gradient"]["points"])
+			for(let gradientColor of service["gradient"]["points"])
 			{
 				let gradientColorRGB = colorUtils.xyBriToRgb(gradientColor.color.xy.x, gradientColor.color.xy.y, (gradientColor.dimming ? service.dimming.brightness : 100));
 


### PR DESCRIPTION
Instead of the planned For Of loop an For In was used. This caused an error when a light supplied this value. Possibly this also corrects the reported problems with "command is executed".