### PR TITLE
Fix update gradient colors instead of concat

### DIFF
--- a/huemagic/hue-bridge-config.js
+++ b/huemagic/hue-bridge-config.js
@@ -267,6 +267,12 @@ module.exports = function(RED)
 					// NO PREVIOUS STATE?
 					if(!previousState) { return false; }
 
+					// IS LIGHT? -> REMOVE PREVIOUS GRADIENT COLORS
+					if(type === "light" && resource["gradient"])
+					{
+						delete previousState["gradient"];
+					}
+
 					// CHECK DIFFERENCES
 					const mergedState = merge.deep(previousState, resource);
 					const updatedResources = diff(previousState, mergedState);


### PR DESCRIPTION
The colors array of the gradient object will be concat with the previous entries. Due to this the array gets longer and longer. If an update contains the gradient object the gradient of the previous state will be deleted now.