### PR TITLE
Fix "The group is not yet available" errors.

### DIFF
--- a/huemagic/utils/messages.js
+++ b/huemagic/utils/messages.js
@@ -119,7 +119,7 @@ class HueGroupMessage
 	constructor(resource, options = {})
 	{
 		let service = Object.values(resource["services"]["grouped_light"])[0];
-		service = options.resources[service.id];
+		// service = options.resources[service.id];
 
 		// GET ALL RESOURCES
 		let allResourcesInsideGroup = {};


### PR DESCRIPTION
Seems to fix #375 and #374

You can install it manually with `npm install git+https://github.com/traverseda/node-red-contrib-huemagic.git`.

Not sure why this fixed it, I'm not a JS programmer, but here is a solution.