### PR TITLE
Commands dropped / bridge overloaded (Err=429) / Connexion issues

### DIFF
--- a/huemagic/hue-bridge-config.js
+++ b/huemagic/hue-bridge-config.js
@@ -60,11 +60,23 @@ module.exports = function(RED)
 					})
 					.catch(function(error)
 					{
-						scope.log("Error requesting info from the bridge. Reconnect in some secs. " + error.message);
-						scope.start();
-					});		
+						// scope.log("Error requesting info from the bridge. Reconnect in some secs. " + error.message);
+						// debug
+						if (error.status !== 429) {
+							scope.log("Error requesting info from the bridge. Reconnect in some secs. " + ((typeof(error.message) == 'undefined') ? JSON.stringify(error) : error.message));
+							// end debug
+							scope.start();
+						} else {
+							// Bridge did not respond because it is currently overloaded (=error 429), but it is still alive, so nothing to do / restart, just keep monitoring as normal
+							// scope.log("Bridge responded but was overloaded for now (ERR:429), no reconnection required for now.");
+							scope.startWatchdog();
+						}
+					});
 				} catch (error) {
-					scope.log("Lost connection with the bridge. Reconnect in some secs. " + error.message);
+					// scope.log("Lost connection with the bridge. Reconnect in some secs. " + error.message);
+					// debug
+					scope.log("Lost connection with the bridge. Reconnect in some secs. " + ((typeof(error.message) == 'undefined') ? JSON.stringify(error) : error.message));
+					// end debug
 					scope.start();
 				}
 			}, 10000);
@@ -337,11 +349,11 @@ module.exports = function(RED)
 
 							// GET CURRENT STATE MESSAGE
 							let currentState = message.msg;
-							return currentState;	
+							return currentState;
 						} catch (error) {
 							return false;
 						}
-						
+
 					}
 					else if(type == "light")
 					{
@@ -660,7 +672,7 @@ module.exports = function(RED)
 		//
 		// START THE MAGIC
 		this.start();
-		
+
 		//
 		// CLOSE NODE / REMOVE EVENT LISTENER
 		this.on('close', function()

--- a/huemagic/hue-brightness.js
+++ b/huemagic/hue-brightness.js
@@ -159,11 +159,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{

--- a/huemagic/hue-group.js
+++ b/huemagic/hue-group.js
@@ -161,11 +161,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -266,11 +266,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -349,11 +349,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -589,11 +589,11 @@ module.exports = function(RED)
 
 					// PATCH!
 					async.retry({
-						times: 3,
+						times: 5,
 						errorFilter: function(err) {
-							return (err.status == 503);
+							return (err.status == 503 || err.status == 429);
 						},
-						interval: function(retryCount) { return retryCount*2000; }
+						interval: function(retryCount) { return 750*retryCount; }
 					},
 					function(callback, results)
 					{

--- a/huemagic/hue-light.js
+++ b/huemagic/hue-light.js
@@ -174,11 +174,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -290,11 +290,11 @@ module.exports = function(RED)
 
 				// APPLY THE EFFECT
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -379,11 +379,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{
@@ -818,11 +818,11 @@ module.exports = function(RED)
 
 					// PATCH!
 					async.retry({
-						times: 3,
+						times: 5,
 						errorFilter: function(err) {
-						    return (err.status == 503);
+							return (err.status == 503 || err.status == 429);
 						},
-						interval: function(retryCount) { return retryCount*2000; }
+						interval: function(retryCount) { return 750*retryCount; }
 					},
 					function(callback, results)
 					{

--- a/huemagic/hue-motion.js
+++ b/huemagic/hue-motion.js
@@ -153,11 +153,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{

--- a/huemagic/hue-rules.js
+++ b/huemagic/hue-rules.js
@@ -113,11 +113,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{

--- a/huemagic/hue-scene.js
+++ b/huemagic/hue-scene.js
@@ -75,11 +75,11 @@ module.exports = function(RED)
 					{
 						// PATCH!
 						async.retry({
-							times: 3,
+							times: 5,
 							errorFilter: function(err) {
-								return (err.status == 503);
+								return (err.status == 503 || err.status == 429);
 							},
-							interval: function(retryCount) { return retryCount*2000; }
+							interval: function(retryCount) { return 750*retryCount; }
 						},
 						function(callback, results)
 						{
@@ -118,11 +118,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{

--- a/huemagic/hue-temperature.js
+++ b/huemagic/hue-temperature.js
@@ -161,11 +161,11 @@ module.exports = function(RED)
 
 				// PATCH!
 				async.retry({
-					times: 3,
+					times: 5,
 					errorFilter: function(err) {
-						return (err.status == 503);
+						return (err.status == 503 || err.status == 429);
 					},
-					interval: function(retryCount) { return retryCount*2000; }
+					interval: function(retryCount) { return 750*retryCount; }
 				},
 				function(callback, results)
 				{

--- a/huemagic/utils/api.js
+++ b/huemagic/utils/api.js
@@ -182,7 +182,7 @@ function API()
 		const scope = this;
 		var fullResource = Object.assign({}, resource);
 
-		if(resource["owner"])
+		if(resource["owner"] && typeof allResources[fullResource["owner"]["rid"]] !== 'undefined')
 		{
 			fullResource = scope.fullResource(allResources[fullResource["owner"]["rid"]], allResources);
 		}

--- a/huemagic/utils/messages.js
+++ b/huemagic/utils/messages.js
@@ -119,8 +119,6 @@ class HueGroupMessage
 	constructor(resource, options = {})
 	{
 		let service = Object.values(resource["services"]["grouped_light"])[0];
-		let onOff = service.on.on;
-		service = options.resources[service.id];
 
 		// GET ALL RESOURCES
 		let allResourcesInsideGroup = {};
@@ -131,7 +129,7 @@ class HueGroupMessage
 
 		this.message = {};
 		this.message.payload = {};
-		this.message.payload.on = onOff;
+		this.message.payload.on = service.on.on;
 		this.message.payload.updated = resource.updated;
 
 		this.message.info = {};
@@ -455,4 +453,3 @@ class HueTemperatureMessage
 //
 // EXPORT
 module.exports = { HueBridgeMessage, HueBrightnessMessage, HueGroupMessage, HueLightMessage, HueMotionMessage, HueRulesMessage, HueButtonsMessage, HueTemperatureMessage }
-

--- a/huemagic/utils/messages.js
+++ b/huemagic/utils/messages.js
@@ -119,6 +119,7 @@ class HueGroupMessage
 	constructor(resource, options = {})
 	{
 		let service = Object.values(resource["services"]["grouped_light"])[0];
+		let onOff = service.on.on;
 		service = options.resources[service.id];
 
 		// GET ALL RESOURCES
@@ -130,7 +131,7 @@ class HueGroupMessage
 
 		this.message = {};
 		this.message.payload = {};
-		this.message.payload.on = service.on.on;
+		this.message.payload.on = onOff;
 		this.message.payload.updated = resource.updated;
 
 		this.message.info = {};


### PR DESCRIPTION
### Context : HUEMagic becomes more often unusable
Based on what I read, it seems HUE has became more and more strict in what it accepts in terms of external API call rates.
Where the bridge easily accepted many calls per second before, it now rejects them more frequently.
Official HUE dev documentation now mentions a maximum of 4 calls per second (but even more strict for calls to groups which are limited to 1 call / second...)
HUEMagic already handled a retry but :
- it only managed it for error code '503'... but now the bridge responds -most of the time- with '429' in case of overload
- retry was performed 3 times (after 2s, then 4s, then 8s)
These caused many issues with commands being delayed to completely lost (not executed).
- The bridge connection was also often 'reset', with an error on console ```Error requesting info from the bridge. Reconnect in some secs. undefined```. This was caused when HUEMagic polled the bridge to ensure connection was still OK at a moment when the bridge was overloaded (err=429)

Because of this, most of us were not able to enjoy HUEMagic nodes :-(

### What did I change ?
- Error '429' is now correctly taken into account (as was 503 before)
- All calls will be retried up to 5 times
- Retry delay will extended by 750ms each time (i.e. 0,75s, 1,5s, ... 3,75)
- HUEMagic will no longer reset connection when it responds as being overloaded
- (In case of connection error, the full returned content (page) is send to console for easier debug)
I have now been running this config for a few weeks and **I do not have any connection / drops anymore**.

### Additional info : merge of other
This pull request also merged #390 from @traverseda and #381 from @Travelbacon, which corrected -very successfully- bugs #375, #374, #377 and #378.
Since then other group issues were reported which *should* also be solved since I think these are actually the same...
(such as #400)

### What you need to do / change ?
I ***strongly*** recommend to configure your HUEMagic bridge node using a single 'worker'. Setting more than 1 will always -logically- worsen the overload effect on the bridge.
If you want to use it from now (not waiting for Foddy to merge & publish it), this is possible by installing it manually using command ```npm install git+https://github.com/fredblo/node-red-contrib-huemagic.git```

